### PR TITLE
Glpiagent FQDN workaround

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,6 +26,15 @@ class glpiagent::install inherits glpiagent {
     require => Package[$glpiagent::package_name],
   }
 
+  file { '/etc/glpi-agent-data.json':
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('glpiagent/glpi-agent-data.erb'),
+    require => Package[$glpiagent::package_name],
+  }
+
   file { '/var/log/glpi-agent':
     ensure => 'directory',
     owner  => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class glpiagent::params {
   $service_enable    = false
   $service_name      = 'glpi-agent'
   $service_ensure    = 'stopped'
+  $additional_content = '/etc/glpi-agent-data.json'
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class glpiagent::params {
   $force             = '1'
   $lazy              = '0'
   $html              = '0'
-  $json              = '0'
+  $json              = '1'
   $assetname_support = '3'
   $no_task           = 'deploy,esx,remoteinventory,wakeonlan'
   $no_httpd          = '1'

--- a/templates/custom.cfg.erb
+++ b/templates/custom.cfg.erb
@@ -18,3 +18,4 @@ no-ssl-check = <%= @no_ssl_check %>
 logger = <%= @logger %>
 logfile = <%= @logfile %>
 logfile-maxsize = 4
+additional-content = <%= @additional_content %>

--- a/templates/glpi-agent-data.erb
+++ b/templates/glpi-agent-data.erb
@@ -1,0 +1,12 @@
+{
+   "content": {
+      "hardware": {
+         "name": "<%= @fqdn %>",
+         "workgroup": "<%= @domain %>"
+      },
+      "operatingsystem": {
+         "dns_domain": "<%= @domain %>",
+         "fqdn": "<%= @fqdn %>"
+      }
+   }
+}


### PR DESCRIPTION
Introducing an extra inventory file which contains:

hardware -> name
hardware -> workgroup
operatingsystem -> dns_domain
operatingsystem -> fqdn

Values are populated from Facter variables and file is pushed by Puppet. In case machine changes it's name, change will be propagated via Puppet agent in max 30 minutes.

Reason for change: Perl's Net::Domain module is not 100% stable and consistent when determining hostname, domain or FQDN. See:

https://github.com/Perl/perl5/issues/17135
https://github.com/glpi-project/glpi-agent/discussions/345

It sporadically determines wrong FQDN and domain, mostly on servers with short domain name which causes non-existing (wrong FQDN) computers to show up in GLPI. 